### PR TITLE
Readers for MS docx, pptx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## [Unreleased]
 - Items in development
 
-## [0.6.0] - 2023-05-xx Mark Graves
+## [0.6.0] - 2023-05-06 Mark Graves
 ### Added
 - Reader for Microsoft docx file (using docx2python)
 - Reader for Microsoft pptx file (using python-pptx, which appears no longer supported). Known issue: some pptx files will not open.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 ### Changed
 - In config data, if term is search sheet is all uppercase, match is now case sensitive
 
-
 ## [0.5.0] - 2023-04-12 Mark Graves
 ### Added
 - Improved documentation of code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## [0.6.0] - 2023-05-xx Mark Graves
 ### Added
 - Reader for Microsoft docx file (using docx2python)
+- Reader for Microsoft pptx file (using python-pptx, which appears no longer supported). Known issue: some pptx files will not open.
 ### Changed
 - In config data, if term is search sheet is all uppercase, match is now case sensitive
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 ## [Unreleased]
 - Items in development
 
+## [0.6.0] - 2023-05-xx Mark Graves
+### Added
+- Reader for Microsoft docx file (using docx2python)
+
+
 ## [0.5.0] - 2023-04-12 Mark Graves
 ### Added
 - Improved documentation of code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ## [0.6.0] - 2023-05-xx Mark Graves
 ### Added
 - Reader for Microsoft docx file (using docx2python)
+### Changed
+- In config data, if term is search sheet is all uppercase, match is now case sensitive
 
 
 ## [0.5.0] - 2023-04-12 Mark Graves

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Lightweight Ethical Auditing Tool (LEAT) identifies ethical concepts in docu
 
 ## Features
 - Excel interface for defining Concepts of interest and the terms and text patterns that define them
-- Searches documents for matching text and idenfifies the documents and location in the documents they occur
+- Searches documents for matching text and identifies the documents and location in the documents they occur
 - Light-weight installation on remote machines
 - Extended functionality for analyzing search results
 
@@ -11,7 +11,7 @@ The Lightweight Ethical Auditing Tool (LEAT) identifies ethical concepts in docu
 
 ### Normal installation
 
-1. Create a virtural environment
+1. Create a virtual environment
 1. Pip install package -- `pip install git+https://github.com/markgraves/leat.git`
 1. Pip install requirements -- `pip install -r requirements.txt`
 

--- a/leat/search/pattern/pattern_builder.py
+++ b/leat/search/pattern/pattern_builder.py
@@ -130,22 +130,30 @@ def build_match_patterns_search(
     for concept, term_list in config_data.items():
         if concept.startswith("_"):
             continue
-        pattern_string = create_terms_pattern(
-            term_list, super_trie=super_trie, allow_wildcards=allow_wildcards
-        )
-        if pattern_string is None:
-            continue
-        # print("DEBUG:", "Building search pattern", pattern_string)
-        flags = re.IGNORECASE
-        match_pattern = MatchPattern(
-            concept,
-            pattern_string,
-            re.compile(pattern_string, flags),
-            flags,
-            source_name,
-            metadata,
-        )
-        result.append(match_pattern)
+        uppercase_terms = []
+        lowercase_terms = []
+        for term in term_list:
+            if term == term.upper():
+                uppercase_terms.append(term)
+            else:
+                lowercase_terms.append(term)
+        for flags in (0, re.IGNORECASE):  # re.NOFLAG # noflag in python 3.11
+            current_terms = lowercase_terms if flags else uppercase_terms
+            pattern_string = create_terms_pattern(
+                current_terms, super_trie=super_trie, allow_wildcards=allow_wildcards
+            )
+            if pattern_string is None:
+                continue
+            print("DEBUG:", "Building search pattern", pattern_string)
+            match_pattern = MatchPattern(
+                concept,
+                pattern_string,
+                re.compile(pattern_string, flags),
+                flags,
+                source_name,
+                metadata,
+            )
+            result.append(match_pattern)
     return result
 
 

--- a/leat/store/core/doc_file.py
+++ b/leat/store/core/doc_file.py
@@ -9,6 +9,7 @@ FILE_EXTENSION_TYPES = {
     "text": "text",
     "txt": "text",
     "docx": "docx",
+    "pptx": "pptx",
 }
 """dict: Mapping from file extensions to file type"""
 

--- a/leat/store/core/doc_file.py
+++ b/leat/store/core/doc_file.py
@@ -95,4 +95,3 @@ class DocFile:
         if self.valid_file():
             return self.filepath
         return None
-    

--- a/leat/store/core/doc_file.py
+++ b/leat/store/core/doc_file.py
@@ -8,6 +8,7 @@ FILE_EXTENSION_TYPES = {
     "pdf": "pdf",
     "text": "text",
     "txt": "text",
+    "docx": "docx",
 }
 """dict: Mapping from file extensions to file type"""
 
@@ -83,3 +84,15 @@ class DocFile:
         if self.valid_file():
             return open(self.filepath, mode=mode, *args)
         return None
+
+    def get_file(self):
+        """
+        Wrapper for getting filepath, checking if file is valid first
+
+        Returns:
+          File path if valid, else None
+        """
+        if self.valid_file():
+            return self.filepath
+        return None
+    

--- a/leat/store/core/doc_store.py
+++ b/leat/store/core/doc_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Collection, Optional, Union
 
 from . import Document, DocFile
-from ..reader import TextReader, PDFReader, DocxReader
+from ..reader import TextReader, PDFReader, DOCXReader, PPTXReader
 
 
 class DocStore:
@@ -18,7 +18,7 @@ class DocStore:
       `ds = DocStore(LocalFileSys(filepath))`
     """
 
-    supported_file_types = {"text", "pdf", "docx"}
+    supported_file_types = {"text", "pdf", "docx", "pptx"}
     """File types supported by the document store"""
 
     def __init__(
@@ -66,7 +66,10 @@ class DocStore:
                         text = PDFReader().read(ifp)
                 elif filetype == "docx":
                     filepath = DocFile(file, filetype=filetype).get_file()
-                    text = DocxReader().read_file(filepath)
+                    text = DOCXReader().read_file(filepath)
+                elif filetype == "pptx":
+                    filepath = DocFile(file, filetype=filetype).get_file()
+                    text = PPTXReader().read_file(filepath)
                 else:
                     print("DEBUG:", "Unknown filetype", filetype, "for", file)
             except OSError:

--- a/leat/store/core/doc_store.py
+++ b/leat/store/core/doc_store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Collection, Optional, Union
 
 from . import Document, DocFile
-from ..reader import TextReader, PDFReader
+from ..reader import TextReader, PDFReader, DocxReader
 
 
 class DocStore:
@@ -18,7 +18,7 @@ class DocStore:
       `ds = DocStore(LocalFileSys(filepath))`
     """
 
-    supported_file_types = {"text", "pdf"}
+    supported_file_types = {"text", "pdf", "docx"}
     """File types supported by the document store"""
 
     def __init__(
@@ -64,6 +64,9 @@ class DocStore:
                 elif filetype == "pdf":
                     with DocFile(file, filetype=filetype).open_file(mode="rb") as ifp:
                         text = PDFReader().read(ifp)
+                elif filetype == "docx":
+                    filepath = DocFile(file, filetype=filetype).get_file()
+                    text = DocxReader().read_file(filepath)
                 else:
                     print("DEBUG:", "Unknown filetype", filetype, "for", file)
             except OSError:

--- a/leat/store/reader/Readme.md
+++ b/leat/store/reader/Readme.md
@@ -1,4 +1,4 @@
-## Adding new types of readers
+## To add new types of readers
 1. Create a reader class, importing from BaseReader, that implements read and/or read_file
 2. Update the __init__.py file to try import or create a stub
 3. Modify leat.store.core.doc_file to update file extension types, 

--- a/leat/store/reader/Readme.md
+++ b/leat/store/reader/Readme.md
@@ -1,0 +1,5 @@
+## Adding new types of readers
+1. Create a reader class, importing from BaseReader, that implements read and/or read_file
+2. Update the __init__.py file to try import or create a stub
+3. Modify leat.store.core.doc_file to update file extension types, 
+4. Modify leat.store.core.doc_store to import class, update supported file types, and add logic to read_document

--- a/leat/store/reader/__init__.py
+++ b/leat/store/reader/__init__.py
@@ -27,11 +27,11 @@ except ModuleNotFoundError:
 
 
 try:
-    from .docx_reader_docx2python import DocxReader
+    from .docx_reader_docx2python import DOCXReader
 except ModuleNotFoundError:
     print("WARNING:", "DOCX reading not available. Need to: pip install docx2python")
 
-    class DocxReader(BaseReader):
+    class DOCXReader(BaseReader):
         """Stub for DOCX reader"""
 
         def __init__(self, *args):
@@ -44,5 +44,27 @@ except ModuleNotFoundError:
             print(
                 "WARNING:",
                 "Cannot read DOCX without package docx2python for file:",
+                filename,
+            )
+
+
+try:
+    from .pptx_reader_python_pptx import PPTXReader
+except ModuleNotFoundError:
+    print("WARNING:", "PPTX reading not available. Need to: pip install python-pptx")
+
+    class DOCXReader(BaseReader):
+        """Stub for PPTX reader"""
+
+        def __init__(self, *args):
+            print(
+                "WARNING:",
+                "PPTX reading not available. Need to: pip install python-pptx",
+            )
+
+        def read_file(self, filename, *args):
+            print(
+                "WARNING:",
+                "Cannot read PPTX without package python-pptx for file:",
                 filename,
             )

--- a/leat/store/reader/__init__.py
+++ b/leat/store/reader/__init__.py
@@ -28,7 +28,7 @@ except ModuleNotFoundError:
 try:
     from .docx_reader_docx2python import DocxReader
 except ModuleNotFoundError:
-     print("WARNING:", "PDF reading not available. Need to: pip install pdfminer.six")
+     print("WARNING:", "DOCX reading not available. Need to: pip install docx2python")
 
      class DocxReader(BaseReader):
         """Stub for DOCX reader"""

--- a/leat/store/reader/__init__.py
+++ b/leat/store/reader/__init__.py
@@ -25,12 +25,13 @@ except ModuleNotFoundError:
             )
             return ""
 
+
 try:
     from .docx_reader_docx2python import DocxReader
 except ModuleNotFoundError:
-     print("WARNING:", "DOCX reading not available. Need to: pip install docx2python")
+    print("WARNING:", "DOCX reading not available. Need to: pip install docx2python")
 
-     class DocxReader(BaseReader):
+    class DocxReader(BaseReader):
         """Stub for DOCX reader"""
 
         def __init__(self, *args):
@@ -45,4 +46,3 @@ except ModuleNotFoundError:
                 "Cannot read DOCX without package docx2python for file:",
                 filename,
             )
-       

--- a/leat/store/reader/__init__.py
+++ b/leat/store/reader/__init__.py
@@ -24,3 +24,25 @@ except ModuleNotFoundError:
                 filename,
             )
             return ""
+
+try:
+    from .docx_reader_docx2python import DocxReader
+except ModuleNotFoundError:
+     print("WARNING:", "PDF reading not available. Need to: pip install pdfminer.six")
+
+     class DocxReader(BaseReader):
+        """Stub for DOCX reader"""
+
+        def __init__(self, *args):
+            print(
+                "WARNING:",
+                "DOCX reading not available. Need to: pip install docx2python",
+            )
+
+        def read_file(self, filename, *args):
+            print(
+                "WARNING:",
+                "Cannot read DOCX without package docx2python for file:",
+                filename,
+            )
+       

--- a/leat/store/reader/docx_reader_docx2python.py
+++ b/leat/store/reader/docx_reader_docx2python.py
@@ -1,0 +1,49 @@
+"""Reader for docx files using docx2python."""
+
+from pathlib import Path
+from typing import Union
+
+from docx2python import docx2python
+
+from . import BaseReader
+
+
+class DocxReader(BaseReader):
+    """Reader for pdf file"""
+
+    def __init__(self, html:bool=False):
+        """
+        Create a reader for DOCX files
+
+        Args:
+          html: bool: return text as html (Default value = False)
+
+        Returns:
+
+        """
+        self.return_html = html
+
+    def read(self, stream):
+        """
+        Extract docx text from stream
+
+        Args:
+          stream: Stream to read from
+
+        Returns:
+          Text read from the stream
+        """
+        raise NotImplementedError
+
+    def read_file(self, filename: Union[str, Path]):
+        """
+        Read text from docx file
+
+        Args:
+          filename: Path | str: Filename to read from
+
+        Returns:
+          Text read from the file
+        """
+        with docx2python(filename, html=self.return_html) as docx_content:
+            return docx_content.text

--- a/leat/store/reader/docx_reader_docx2python.py
+++ b/leat/store/reader/docx_reader_docx2python.py
@@ -8,8 +8,8 @@ from docx2python import docx2python
 from . import BaseReader
 
 
-class DocxReader(BaseReader):
-    """Reader for pdf file"""
+class DOCXReader(BaseReader):
+    """Reader for docx file"""
 
     def __init__(self, html: bool = False):
         """

--- a/leat/store/reader/docx_reader_docx2python.py
+++ b/leat/store/reader/docx_reader_docx2python.py
@@ -11,7 +11,7 @@ from . import BaseReader
 class DocxReader(BaseReader):
     """Reader for pdf file"""
 
-    def __init__(self, html:bool=False):
+    def __init__(self, html: bool = False):
         """
         Create a reader for DOCX files
 

--- a/leat/store/reader/pptx_reader_python_pptx.py
+++ b/leat/store/reader/pptx_reader_python_pptx.py
@@ -1,0 +1,82 @@
+"""Reader for docx files using docx2python."""
+
+from pathlib import Path
+from typing import Union
+from zipfile import BadZipFile
+
+from pptx import Presentation
+
+from . import BaseReader
+
+
+class PPTXReader(BaseReader):
+    """Reader for pptx file"""
+
+    def __init__(self):
+        """
+        Create a reader for PPTX files
+
+        Returns:
+
+        """
+        pass
+
+    def read(self, stream):
+        """
+        Extract pptx text from stream
+
+        Args:
+          stream: Stream to read from
+
+        Returns:
+          Text read from the stream
+        """
+        try:
+            return self.get_text(Presentation(stream))
+        except BadZipFile:
+            print(
+                "WARNING:",
+                "Cannot read PPTX due to unknown format issue",
+            )
+            return ""
+
+    def read_file(self, filename: Union[str, Path]):
+        """
+        Read text from pptx file
+
+        Args:
+          filename: Path | str: Filename to read from
+
+        Returns:
+          Text read from the file
+        """
+        try:
+            return self.get_text(Presentation(filename))
+        except BadZipFile:
+            print(
+                "WARNING:",
+                "Cannot read PPTX due to unknown format issue:",
+                filename,
+            )
+            return ""
+
+    def get_text(self, prs: Presentation):
+        """
+        Read text from pptx presentation
+
+        Args:
+          filename: prs | Presentation: Presentation to read from
+
+        Returns:
+          Text read from the presentation
+        """
+
+        result = []
+        for slide in prs.slides:
+            slide_result = []
+            for shape in slide.shapes:
+                if hasattr(shape, "text"):
+                    slide_result.append(shape.text.strip())
+            if slide_result:
+                result.append("\n".join(slide_result))
+        return "\n".join(result)


### PR DESCRIPTION
Added
- Reader for Microsoft docx file (using docx2python)
- Reader for Microsoft pptx file (using python-pptx, which appears no longer supported). Known issue: some pptx files will not open.

Changed
- In config data, if term is search sheet is all uppercase, match is now case sensitive